### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/apps/fe/project.json
+++ b/apps/fe/project.json
@@ -28,12 +28,12 @@
         },
         "build": {
             "executor": "@nx/next:build",
-            "outputs": ["{options.outputPath}"],
-            "defaultConfiguration": "production",
-            "cache": true,
             "options": {
                 "outputPath": "dist/apps/fe"
             },
+            "outputs": ["{options.outputPath}"],
+            "defaultConfiguration": "production",
+            "cache": true,
             "configurations": {
                 "development": {
                     "outputPath": "."

--- a/nx.json
+++ b/nx.json
@@ -2,10 +2,7 @@
     "$schema": "./node_modules/nx/schemas/nx-schema.json",
     "defaultBase": "master",
     "namedInputs": {
-        "default": [
-            "{projectRoot}/**/*",
-            "sharedGlobals"
-        ],
+        "default": ["{projectRoot}/**/*", "sharedGlobals"],
         "production": [
             "default",
             "!{projectRoot}/.eslintrc.json",
@@ -41,9 +38,7 @@
             "options": {
                 "targetName": "test"
             },
-            "exclude": [
-                "apps/be-e2e/**/*"
-            ]
+            "exclude": ["apps/be-e2e/**/*"]
         },
         {
             "plugin": "@nx/next/plugin",

--- a/nx.json
+++ b/nx.json
@@ -2,7 +2,10 @@
     "$schema": "./node_modules/nx/schemas/nx-schema.json",
     "defaultBase": "master",
     "namedInputs": {
-        "default": ["{projectRoot}/**/*", "sharedGlobals"],
+        "default": [
+            "{projectRoot}/**/*",
+            "sharedGlobals"
+        ],
         "production": [
             "default",
             "!{projectRoot}/.eslintrc.json",
@@ -38,7 +41,9 @@
             "options": {
                 "targetName": "test"
             },
-            "exclude": ["apps/be-e2e/**/*"]
+            "exclude": [
+                "apps/be-e2e/**/*"
+            ]
         },
         {
             "plugin": "@nx/next/plugin",
@@ -59,7 +64,7 @@
             }
         }
     ],
-    "nxCloudAccessToken": "YTNiZTM5ZDgtNGEyMS00OGM3LTlkNmItNjc3YzNkNTZhMGI1fHJlYWQtd3JpdGU=",
+    "nxCloudAccessToken": "NTY4ZjhhNzUtM2MzYy00MmQ5LWFmNTAtZTBlYzQ3N2JiNjVlfHJlYWQtd3JpdGU=",
     "generators": {
         "@nx/next": {
             "application": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "scripts": {
         "fe": "yarn nx dev:rf fe",
         "be": "yarn nx serve be --configuration=development",
-        "fe:build": "yarn nx build fe --skip-nx-cache",
-        "fe:prod": "yarn nx start fe --configuration=production --skip-nx-cache",
-        "be:prod": "yarn nx serve be --configuration=production --skip-nx-cache"
+        "fe:build": "yarn nx build fe",
+        "fe:prod": "yarn nx start fe --configuration=production",
+        "be:prod": "yarn nx serve be --configuration=production"
     },
     "dependencies": {
         "@ant-design/icons": "^5.3.7",

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
     "framework": "nextjs",
     "regions": ["sin1"],
     "installCommand": "yarn install --immutable",
-    "buildCommand": "yarn nx build fe --skip-nx-cache",
+    "buildCommand": "yarn nx build fe",
     "outputDirectory": "dist/apps/fe/.next",
     "cleanUrls": true
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 

This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/667f8a8c7e7db61d895c7fbc/workspaces/667f8aa9e8e16f575ee82d37

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated build and start scripts for frontend and backend applications to remove the `--skip-nx-cache` flag, improving build and start consistency.
  - Modified `build` configuration settings for better environment-specific builds.
  - Updated `nxCloudAccessToken` for enhanced security and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->